### PR TITLE
Use io.ReadFull for reading decompressed tls data

### DIFF
--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -100,7 +100,7 @@ func (hs *clientHandshakeStateTLS13) decompressCert(m utlsCompressedCertificateM
 	rawMsg[2] = uint8(m.uncompressedLength >> 8)
 	rawMsg[3] = uint8(m.uncompressedLength)
 
-	n, err := decompressed.Read(rawMsg[4:])
+	n, err := io.ReadFull(decompressed, rawMsg[4:])
 	if err != nil && !errors.Is(err, io.EOF) {
 		c.sendAlert(alertBadCertificate)
 		return nil, err


### PR DESCRIPTION
Currently it only reads partially from the buffer. In some cases it can return fewer bytes which corrupts the tls handshake. 

For me it ends up with "ECDSA signature verification error" because the public key parsed from the malformed certificate doesn't match the server's actual key. But the fix is just to read the buffer in full so we don't end up with a malformed cert.

Encountered error when using profiles.Safari_IOS_17_0 on example.com (should be any profile advertising and using compression)